### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 /vendor/
+.phpunit.result.cache
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 7.0
-    - 7.1
     - 7.2
+    - 7.3
+    - 7.4
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": { "lewiscowles\\core\\": "src" }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -12,16 +12,18 @@ class BaseTest extends TestCase
 
     const TIME = 1469918176385;
 
-    public function setup()
+    protected function setup(): void
     {
         $this->ulid = new Ulid($this->getTimeSource(), $this->getLcgRandom());
     }
 
-    public function getTimeSource() {
+    public function getTimeSource()
+    {
         return new PHPTimeSource();
     }
 
-    public function getLcgRandom() {
+    public function getLcgRandom()
+    {
         return new LcgRandomGenerator();
     }
 


### PR DESCRIPTION
# Changed log
- The `php-7.0` and `php-7.1` versions are inactive for official PHP support. Using the `php-7.2` version to be minimum PHP version requirement.
- Upgrading the PHPUnit version to be `8.x` for above PHP version requirement changing.
- To make consistency coding style, let all method blocks are same.
- After `PHPUnit 8.x` running has been done, it will generate the `.phpunit.result.cache`.
To prevent this cached file to be under Git version control, let this file on `.gitignore` file.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures), it should be `protected function setUp(): void`.