### PR TITLE
Fix timestamp to return milliseconds in PHPTimeSource

### DIFF
--- a/src/Concepts/Time/PHPTimeSource.php
+++ b/src/Concepts/Time/PHPTimeSource.php
@@ -6,6 +6,6 @@ class PHPTimeSource implements TimeSourceInterface
 {
     public function getTime(): int
     {
-        return time();
+        return (int) (microtime(true) * 1000);
     }
 }


### PR DESCRIPTION
This PR addresses an issue with the `PHPTimeSource` class, where the `getTime()` method was returning the current time in seconds since the Unix epoch, as opposed to milliseconds, which is expected by the ULID specification.

### Changes:
- Updated the `getTime()` method in `PHPTimeSource` to return the current timestamp in milliseconds.

### Rationale:
The ULID specification requires the timestamp to be in milliseconds since the Unix epoch. The previous implementation, which used the PHP `time()` function, returned the timestamp in seconds, leading to ULIDs being generated with dates close to the start of the Unix epoch (1st January 1970). This fix ensures that ULIDs are generated with the correct timestamp, adhering to the ULID specification.
