### PR TITLE
fix: allow infection extension installer in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
             "email": "lewiscowles@me.com"
         }
     ],
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
+    }
 }


### PR DESCRIPTION
I think this will fix the build pipelines. At least it worked locally on my mac.